### PR TITLE
dave: [dave-proposed] Add documentation for log_add_callback and callback semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,83 @@ int main(void) {
 }
 ```
 
+### Callback Destinations
+
+Beyond file pointers, the logger lets you register any function that matches the `log_LogFn` signature as a log destination. This is handy when you want to ship log lines somewhere a `FILE *` can't reach — a ring buffer, a network socket, a GUI console, or a remote telemetry service.
+
+The callback signature is:
+
+```c
+typedef void (*log_LogFn)(log_event_t *ev);
+```
+
+You register a callback (and an optional `udata` pointer that gets threaded through to your function) with `log_add_destination()`:
+
+```c
+int log_add_destination(log_LogFn fn, void *udata, int level);
+```
+
+- `fn`    — your callback function
+- `udata` — arbitrary context pointer; it arrives in `ev->udata` inside your callback (pass `NULL` if you don't need it)
+- `level` — minimum severity this destination will receive
+
+Returns `0` on success, `-1` if the destination table is full (it holds up to 420 entries).
+
+**Complete example — writing log lines into a fixed-size ring buffer:**
+
+```c
+#include "logger/logger.h"
+#include <stdio.h>
+#include <string.h>
+
+#define RING_SIZE 64
+#define LINE_SIZE 256
+
+typedef struct {
+    char  lines[RING_SIZE][LINE_SIZE];
+    int   head;   /* next slot to write */
+    int   count;  /* total entries stored (capped at RING_SIZE) */
+} ring_buf_t;
+
+/* This is our log_LogFn callback. The logger calls it once per log line
+ * that meets the registered minimum level. ev->udata is whatever pointer
+ * we passed to log_add_destination(). */
+static void cb_ring_buffer(log_event_t *ev) {
+    ring_buf_t *ring = (ring_buf_t *)ev->udata;
+
+    /* Build a single formatted string from the variadic args. */
+    vsnprintf(ring->lines[ring->head], LINE_SIZE, ev->fmt, ev->arg_list);
+
+    ring->head  = (ring->head + 1) % RING_SIZE;
+    if (ring->count < RING_SIZE) ring->count++;
+}
+
+int main(void) {
+    ring_buf_t ring = {0};
+
+    log_set_level(LOG_DEBUG);
+
+    /* Register our callback; it will receive DEBUG and above. */
+    log_add_destination(cb_ring_buffer, &ring, LOG_DEBUG);
+
+    log_info("Server starting on port %d", 8080);
+    log_warn("Config file not found, using defaults");
+    log_error("Failed to bind socket: %s", "address already in use");
+
+    /* Dump whatever ended up in the ring buffer. */
+    printf("--- ring buffer contents (%d entries) ---\n", ring.count);
+    for (int i = 0; i < ring.count; i++) {
+        int slot = (ring.head - ring.count + i + RING_SIZE) % RING_SIZE;
+        printf("  [%d] %s\n", i, ring.lines[slot]);
+    }
+    return 0;
+}
+```
+
+**Thread-safety note:** The logger itself does not hold a lock when invoking callbacks, so if your application logs from multiple threads you are responsible for protecting any shared state inside your callback (e.g., wrap the ring-buffer writes in a mutex). `ev->arg_list` is valid only for the duration of the callback — do not store the `va_list` and use it later.
+
+---
+
 To rate-limit a noisy log call (e.g., inside a loop), use the `throttled` macro from `logger/throttled.h`:
 
 ```c


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #9

### Plan
Add a new 'Callback Destinations' section to the README that documents log_add_callback (actually log_add_destination) and the log_LogFn typedef, includes a complete compilable example showing how to write and register a callback, and notes thread-safety expectations. The example will be simple and self-contained so a reader can drop it straight into their project.

### Summary
Alright folks, here's what we did: I added a brand-new 'Callback Destinations' section to the README right before the throttled-macro section. It explains the log_LogFn typedef and the log_add_destination() signature, then walks through a complete, compilable ring-buffer example so readers can see exactly what a callback looks like, how udata flows in, and how to register the thing. I also dropped in a thread-safety callout — the logger doesn't hold any locks when it fires callbacks, so that's the caller's job — and a reminder that ev->arg_list is only valid for the duration of the call. No source files were touched; this was a pure documentation change, clean and focused.

### Files Changed
- `README.md` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
