### PR TITLE
dave: [dave-proposed] Add log_get_level() function to query current minimum log level

### DIFF
--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -64,6 +64,10 @@ static void log_to_stream(log_event_t *ev) {
 }
 
 //so we're here, and we want to set log level to 0
+int log_get_level(void) {
+    return log_global_cfg.level;
+}
+
 void log_set_level(int level) {
 
     //this is the key check that determines whether or not our level set works

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -94,6 +94,7 @@ enum {
 /* function declarations, all of our function definitions live in the logger.c file */
 const char* log_level_string(int level);
 void log_set_level(int level);
+int  log_get_level(void);
 void log_set_quiet(bool enable);
 int log_add_destination(log_LogFn fn, void *udata, int level);
 int log_add_fp(FILE *fp, int level);

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -8,3 +8,14 @@ extern "C" {
 BOOST_AUTO_TEST_CASE(test_logging) {
 
 }
+
+BOOST_AUTO_TEST_CASE(test_get_level_returns_set_level) {
+    log_set_level(LOG_WARN);
+    BOOST_CHECK_EQUAL(log_get_level(), LOG_WARN);
+
+    log_set_level(LOG_DEBUG);
+    BOOST_CHECK_EQUAL(log_get_level(), LOG_DEBUG);
+
+    log_set_level(LOG_FATAL);
+    BOOST_CHECK_EQUAL(log_get_level(), LOG_FATAL);
+}


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #11

### Plan
Add a log_get_level() function to logger.h (declaration) and logger.c (definition), then add a unit test in tests/test_logger.cpp that verifies it returns the correct level after calls to log_set_level().

### Summary
Alright folks, welcome back to the garage! This was a nice clean little job — like adding a dipstick to an engine that already had a fill cap. We already had log_set_level() to pour the oil in, but no way to check the level afterward. So I added log_get_level() as a one-liner getter in logger.c that just returns log_global_cfg.level, wired up the declaration in logger.h right next to its setter sibling so the API reads naturally, and then wrote a unit test in tests/test_logger.cpp that sets the level to WARN, DEBUG, and FATAL in sequence and verifies log_get_level() echoes back the right value each time. Zero new dependencies, zero behavior changes — just a missing window into state that was already there.

### Files Changed
- `src/logger/logger.h` (edit)
- `src/logger/logger.c` (edit)
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
