### PR TITLE
dave: [dave-proposed] Add log_get_quiet() getter to query quiet mode state

### DIFF
--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -79,7 +79,16 @@ void log_set_level(int level) {
 }
 
 void log_set_quiet(bool enable) {
-    if (log_global_cfg.quiet_cli_override == false) { log_global_cfg.quiet = enable; } 
+    if (log_global_cfg.quiet_cli_override == false) { log_global_cfg.quiet = enable; }
+}
+
+/**
+ * Returns the current quiet mode state.
+ *
+ * @return 1 if quiet mode is enabled (all log output suppressed), 0 otherwise.
+ */
+int log_get_quiet(void) {
+    return log_global_cfg.quiet ? 1 : 0;
 }
 
 /* this is where we register our logging function */

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -96,6 +96,7 @@ const char* log_level_string(int level);
 void log_set_level(int level);
 int  log_get_level(void);
 void log_set_quiet(bool enable);
+int  log_get_quiet(void);
 int log_add_destination(log_LogFn fn, void *udata, int level);
 int log_add_fp(FILE *fp, int level);
 

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -19,3 +19,19 @@ BOOST_AUTO_TEST_CASE(test_get_level_returns_set_level) {
     log_set_level(LOG_FATAL);
     BOOST_CHECK_EQUAL(log_get_level(), LOG_FATAL);
 }
+
+BOOST_AUTO_TEST_CASE(test_get_quiet_returns_enabled_state) {
+    log_set_quiet(false);
+    BOOST_CHECK_EQUAL(log_get_quiet(), 0);
+
+    log_set_quiet(true);
+    BOOST_CHECK_EQUAL(log_get_quiet(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_quiet_reflects_toggled_state) {
+    log_set_quiet(true);
+    BOOST_CHECK_EQUAL(log_get_quiet(), 1);
+
+    log_set_quiet(false);
+    BOOST_CHECK_EQUAL(log_get_quiet(), 0);
+}


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #13

### Plan
Add log_get_quiet() declaration to logger.h adjacent to log_set_quiet(), then implement it in logger.c to return the quiet field from the global config struct. Finally, add two unit test cases in tests/test_logger.cpp to verify the getter reflects what log_set_quiet() sets.

### Summary
Alright, this one's pretty straightforward — like adding a window to a wall that already had a door. I added log_get_quiet() as a symmetric getter right next to log_set_quiet() in logger.h (just the way a good workbench keeps paired tools side by side), then wired up the implementation in logger.c to return 1 or 0 based on the quiet field in the global config struct, complete with a docstring explaining what it gives back. Over in the test file I added two new Boost test cases — one that verifies quiet mode returning 0 when disabled and 1 when enabled, and a second that toggles the state the other direction to make sure we're not getting a hardcoded value. Clean, consistent, symmetric — exactly what the API needed.

### Files Changed
- `src/logger/logger.h` (edit)
- `src/logger/logger.c` (edit)
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
