### PR TITLE
dave: custom logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,30 @@ int main(void) {
 }
 ```
 
+### Stdout / Stderr Convenience Functions
+
+In addition to `log_add_fp()`, two convenience wrappers let you direct output to the standard streams without holding a `FILE *` yourself:
+
+```c
+log_add_stdout(LOG_DEBUG);  /* send DEBUG and above to stdout */
+log_add_stderr(LOG_WARN);   /* send WARN and above to stderr  */
+```
+
+Both functions accept the same log-level argument as `log_add_fp()` and return `0` on success or `-1` if the destination table is full.
+
+### Resetting Destinations at Runtime
+
+Call `log_remove_destinations()` to clear every registered destination in one shot. This is handy between test cases or when you want to reconfigure where logs go without restarting your program:
+
+```c
+log_remove_destinations();        /* clear everything           */
+log_add_fp(new_fp, LOG_INFO);     /* register fresh destination */
+```
+
+### Default Fallback Behaviour
+
+If you have not registered any destinations, the logger falls back to writing to `stderr` automatically so log output is never silently swallowed. The moment you register at least one destination, the fallback is bypassed and only your registered destinations receive log lines.
+
 ### Callback Destinations
 
 Beyond file pointers, the logger lets you register any function that matches the `log_LogFn` signature as a log destination. This is handy when you want to ship log lines somewhere a `FILE *` can't reach — a ring buffer, a network socket, a GUI console, or a remote telemetry service.

--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -107,6 +107,23 @@ int log_add_fp(FILE *fp, int level) {
     return log_add_destination(log_to_stream, fp, level);
 }
 
+/* convenience: register stdout as a log destination */
+int log_add_stdout(int level) {
+    return log_add_destination(log_to_stream, stdout, level);
+}
+
+/* convenience: register stderr as a log destination */
+int log_add_stderr(int level) {
+    return log_add_destination(log_to_stream, stderr, level);
+}
+
+/* remove all registered destinations (useful for test teardown and runtime reconfiguration) */
+void log_remove_destinations(void) {
+    for (int i = 0; i < MAX_LOG_DESTINATIONS; i++) {
+        log_global_cfg.destinations[i] = (log_dest_t){ NULL, NULL, 0 };
+    }
+}
+
 /* populate our log event struct with time and output stream data */
 static void init_event(log_event_t *ev, void *udata) {
     if (!ev->time) {
@@ -137,17 +154,23 @@ void log_log(int level, const char *file, int line, const char *fmt, ...) {
     };
 
     if (!log_global_cfg.quiet && level >= log_global_cfg.level) {
-        
-        /* finishes populating ev with time and output stream (udata) */
-        init_event(&ev, stderr);
 
-        /* sets up the arg list with all of our extra args if any */
-        va_start(ev.arg_list, fmt);
-        
-        /* HERE'S WHERE LOGGING WORK HAPPENS AND STUFF ACTUALLY GETS PRINTED */
-        log_to_stream(&ev);
-        
-        va_end(ev.arg_list);
+        /* If no destinations are registered, fall back to stderr so log output
+         * is never silently swallowed. */
+        bool has_destinations = false;
+        for (int i = 0; i < MAX_LOG_DESTINATIONS; i++) {
+            if (log_global_cfg.destinations[i].fn) {
+                has_destinations = true;
+                break;
+            }
+        }
+
+        if (!has_destinations) {
+            init_event(&ev, stderr);
+            va_start(ev.arg_list, fmt);
+            log_to_stream(&ev);
+            va_end(ev.arg_list);
+        }
     }
 
     /* you can ignore this for now. 

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -97,7 +97,10 @@ void log_set_level(int level);
 int  log_get_level(void);
 void log_set_quiet(bool enable);
 int  log_get_quiet(void);
-int log_add_destination(log_LogFn fn, void *udata, int level);
-int log_add_fp(FILE *fp, int level);
+int  log_add_destination(log_LogFn fn, void *udata, int level);
+int  log_add_fp(FILE *fp, int level);
+int  log_add_stdout(int level);
+int  log_add_stderr(int level);
+void log_remove_destinations(void);
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -2,14 +2,28 @@ extern "C" {
 #include "logger/logger.c"
 }
 
+#include <cstdio>
+#include <cstring>
+
 #define BOOST_TEST_MODULE LoggerTest
 #include <boost/test/included/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(test_logging) {
-
+/* Helper: reset all mutable global logger state between tests. */
+static void reset_logger(void) {
+    log_global_cfg.level              = LOG_TRACE;
+    log_global_cfg.quiet              = false;
+    log_global_cfg.level_cli_override = false;
+    log_global_cfg.quiet_cli_override = false;
+    log_remove_destinations();
 }
 
+/* ------------------------------------------------------------------ */
+/* Level API                                                           */
+/* ------------------------------------------------------------------ */
+
 BOOST_AUTO_TEST_CASE(test_get_level_returns_set_level) {
+    reset_logger();
+
     log_set_level(LOG_WARN);
     BOOST_CHECK_EQUAL(log_get_level(), LOG_WARN);
 
@@ -20,7 +34,23 @@ BOOST_AUTO_TEST_CASE(test_get_level_returns_set_level) {
     BOOST_CHECK_EQUAL(log_get_level(), LOG_FATAL);
 }
 
+BOOST_AUTO_TEST_CASE(test_set_level_all_values) {
+    reset_logger();
+
+    const int levels[] = { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
+    for (int i = 0; i < 6; i++) {
+        log_set_level(levels[i]);
+        BOOST_CHECK_EQUAL(log_get_level(), levels[i]);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Quiet API                                                           */
+/* ------------------------------------------------------------------ */
+
 BOOST_AUTO_TEST_CASE(test_get_quiet_returns_enabled_state) {
+    reset_logger();
+
     log_set_quiet(false);
     BOOST_CHECK_EQUAL(log_get_quiet(), 0);
 
@@ -29,9 +59,157 @@ BOOST_AUTO_TEST_CASE(test_get_quiet_returns_enabled_state) {
 }
 
 BOOST_AUTO_TEST_CASE(test_get_quiet_reflects_toggled_state) {
+    reset_logger();
+
     log_set_quiet(true);
     BOOST_CHECK_EQUAL(log_get_quiet(), 1);
 
     log_set_quiet(false);
     BOOST_CHECK_EQUAL(log_get_quiet(), 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* Destination management                                             */
+/* ------------------------------------------------------------------ */
+
+BOOST_AUTO_TEST_CASE(test_add_fp_returns_success) {
+    reset_logger();
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+
+    int rc = log_add_fp(fp, LOG_TRACE);
+    BOOST_CHECK_EQUAL(rc, 0);
+
+    fclose(fp);
+}
+
+BOOST_AUTO_TEST_CASE(test_add_stdout_returns_success) {
+    reset_logger();
+
+    int rc = log_add_stdout(LOG_INFO);
+    BOOST_CHECK_EQUAL(rc, 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_add_stderr_returns_success) {
+    reset_logger();
+
+    int rc = log_add_stderr(LOG_WARN);
+    BOOST_CHECK_EQUAL(rc, 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_remove_destinations_clears_all) {
+    reset_logger();
+
+    /* Register a few destinations */
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_TRACE);
+
+    log_remove_destinations();
+
+    /* After clearing, we should be able to fill slots from zero again */
+    int rc = log_add_stderr(LOG_TRACE);
+    BOOST_CHECK_EQUAL(rc, 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_file_destination_receives_output) {
+    reset_logger();
+    log_set_level(LOG_TRACE);
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+
+    log_add_fp(fp, LOG_TRACE);
+    log_info("hello from test");
+
+    /* Rewind and verify something was written */
+    rewind(fp);
+    char buf[256] = {0};
+    size_t n = fread(buf, 1, sizeof(buf) - 1, fp);
+    BOOST_CHECK_GT(n, (size_t)0);
+    BOOST_CHECK(strstr(buf, "hello from test") != NULL);
+
+    fclose(fp);
+}
+
+BOOST_AUTO_TEST_CASE(test_file_destination_respects_level_filter) {
+    reset_logger();
+    log_set_level(LOG_TRACE);
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+
+    /* Register file at WARN — DEBUG messages should not appear */
+    log_add_fp(fp, LOG_WARN);
+    log_debug("this should be filtered");
+
+    rewind(fp);
+    char buf[256] = {0};
+    fread(buf, 1, sizeof(buf) - 1, fp);
+    BOOST_CHECK(strstr(buf, "this should be filtered") == NULL);
+
+    fclose(fp);
+}
+
+BOOST_AUTO_TEST_CASE(test_file_destination_passes_at_or_above_level) {
+    reset_logger();
+    log_set_level(LOG_TRACE);
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+
+    log_add_fp(fp, LOG_WARN);
+    log_warn("this should pass through");
+
+    rewind(fp);
+    char buf[256] = {0};
+    fread(buf, 1, sizeof(buf) - 1, fp);
+    BOOST_CHECK(strstr(buf, "this should pass through") != NULL);
+
+    fclose(fp);
+}
+
+/* ------------------------------------------------------------------ */
+/* Callback destination                                               */
+/* ------------------------------------------------------------------ */
+
+static int        s_callback_hit   = 0;
+static int        s_callback_level = -1;
+static char       s_callback_msg[256];
+
+static void test_callback(log_event_t *ev) {
+    s_callback_hit++;
+    s_callback_level = ev->level;
+    vsnprintf(s_callback_msg, sizeof(s_callback_msg), ev->fmt, ev->arg_list);
+}
+
+BOOST_AUTO_TEST_CASE(test_callback_destination_is_invoked) {
+    reset_logger();
+    log_set_level(LOG_TRACE);
+
+    s_callback_hit   = 0;
+    s_callback_level = -1;
+    memset(s_callback_msg, 0, sizeof(s_callback_msg));
+
+    log_add_destination(test_callback, NULL, LOG_TRACE);
+    log_info("callback test message");
+
+    BOOST_CHECK_EQUAL(s_callback_hit, 1);
+    BOOST_CHECK_EQUAL(s_callback_level, LOG_INFO);
+    BOOST_CHECK(strstr(s_callback_msg, "callback test message") != NULL);
+}
+
+BOOST_AUTO_TEST_CASE(test_callback_not_invoked_in_quiet_mode) {
+    reset_logger();
+    log_set_level(LOG_TRACE);
+    log_set_quiet(true);
+
+    s_callback_hit = 0;
+
+    log_add_destination(test_callback, NULL, LOG_TRACE);
+    log_info("should be suppressed");
+
+    /* quiet mode suppresses the stderr fallback but NOT registered destinations —
+     * this test documents the current behaviour so changes to it are explicit. */
+    BOOST_CHECK_EQUAL(s_callback_hit, 0);
 }


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #1

### Plan
The issue asks for a flexible logger that supports stdout/file output optionally. Looking at the existing code, the core logger already has the callback/destination system, but it always writes to stderr by default and the 'stdout' option is missing from the public API. I'll add log_add_stdout() and log_add_stderr() convenience functions, add a log_remove_destinations() reset function for test hygiene, expand the test suite with meaningful tests covering file and callback destinations, and update the README to document the full API properly.

### Summary
Alright folks, welcome back to the garage! So the issue asked for a flexible logger that can write to stdout or a file optionally, and I wanted to make sure it was easy to wire up without a lot of ceremony. The core destination system was already in there — I pulled back the curtain on it by adding log_add_stdout() and log_add_stderr() convenience wrappers so you're not hunting for FILE* handles just to point at the standard streams. I also added log_remove_destinations() which is one of those 'obvious in hindsight' utilities — you need it for clean test teardown and runtime reconfiguration both. The default stderr fallback was reworked so it only fires when no destinations are registered, which is the right contract: register a destination and you're in control. The test suite got a proper overhaul with reset_logger() hygiene, level-filter verification, tmpfile-based output capture, and callback destination tests. And the README got the docs it deserved. This one's pretty well buttoned up.

### Files Changed
- `src/logger/logger.h` (edit)
- `src/logger/logger.c` (edit)
- `src/logger/logger.c` (edit)
- `tests/test_logger.cpp` (edit)
- `README.md` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
