### PR TITLE
dave: Figure out how to best integrate Allegro on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,49 @@ include_directories(${Boost_INCLUDE_DIRS})
 add_executable(test_logger tests/test_logger.cpp)
 
 target_link_libraries(test_logger ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} logger)
+
+# ---------------------------------------------------------------------------
+# Allegro 5 integration (optional)
+# ---------------------------------------------------------------------------
+# Strategy: try CMake's built-in find_package first (works when Allegro
+# installs a proper AllegroConfig.cmake / allegro-config.cmake).  If that
+# fails, fall back to pkg-config, which is the common case on Linux distros
+# that ship allegro5 via their package manager (apt, pacman, dnf, etc.).
+# If neither mechanism finds Allegro, the main library and tests still build
+# normally — Allegro targets are simply skipped.
+
+find_package(Allegro 5 QUIET)
+
+if(NOT Allegro_FOUND)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(ALLEGRO QUIET allegro-5)
+        if(ALLEGRO_FOUND)
+            # Wrap the pkg-config result in an IMPORTED target so downstream
+            # targets can use target_link_libraries() uniformly.
+            add_library(allegro::allegro INTERFACE IMPORTED)
+            target_include_directories(allegro::allegro
+                INTERFACE ${ALLEGRO_INCLUDE_DIRS})
+            target_link_libraries(allegro::allegro
+                INTERFACE ${ALLEGRO_LIBRARIES})
+            target_compile_options(allegro::allegro
+                INTERFACE ${ALLEGRO_CFLAGS_OTHER})
+            target_link_directories(allegro::allegro
+                INTERFACE ${ALLEGRO_LIBRARY_DIRS})
+            set(ALLEGRO_TARGET allegro::allegro)
+        endif()
+    endif()
+elseif(TARGET allegro)
+    set(ALLEGRO_TARGET allegro)
+elseif(TARGET Allegro::allegro)
+    set(ALLEGRO_TARGET Allegro::allegro)
+endif()
+
+if(ALLEGRO_TARGET)
+    message(STATUS "Allegro 5 found — building allegro_demo target")
+    add_executable(allegro_demo src/allegro_demo/main.c)
+    target_link_libraries(allegro_demo PRIVATE logger ${ALLEGRO_TARGET})
+else()
+    message(STATUS "Allegro 5 not found — skipping allegro_demo target."
+        " Install liballegro5-dev (Debian/Ubuntu) or allegro (Arch/Fedora) to enable it.")
+endif()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,37 @@ make
 
 The build produces a `logger` static library and a `test_logger` test executable.
 
+### Allegro 5 (optional — Linux)
+
+The build system will automatically detect [Allegro 5](https://liballegro.org/) and, if found, compile a small `allegro_demo` executable that opens a window and exercises the logger alongside Allegro's event loop. This is the recommended way to verify that the two libraries play nicely together on your system.
+
+**Install Allegro 5 on common Linux distros:**
+
+```bash
+# Debian / Ubuntu
+sudo apt install liballegro5-dev liballegro-font5-dev liballegro-primitives5-dev
+
+# Arch Linux
+sudo pacman -S allegro
+
+# Fedora / RHEL
+sudo dnf install allegro5-devel
+```
+
+After installing, just re-run `cmake ..` and `make` — CMake will detect the library via `find_package` first, then fall back to `pkg-config` if a CMake config file is not present. You should see a confirmation line in the CMake output:
+
+```
+-- Allegro 5 found — building allegro_demo target
+```
+
+If Allegro is not installed you will instead see:
+
+```
+-- Allegro 5 not found — skipping allegro_demo target.
+```
+
+and everything else will build normally. No breakage, no mandatory dependency.
+
 ## Basic Usage
 
 Include the logger header, optionally configure a log level and/or a file destination, then use the level macros to write log lines.

--- a/src/allegro_demo/main.c
+++ b/src/allegro_demo/main.c
@@ -1,0 +1,125 @@
+#include <allegro5/allegro.h>
+#include <allegro5/allegro_font.h>
+#include <allegro5/allegro_primitives.h>
+
+#include "logger/logger.h"
+
+#define SCREEN_W 640
+#define SCREEN_H 480
+#define TARGET_FPS 60.0
+
+int main(void)
+{
+    log_set_level(LOG_INFO);
+    log_info("CarlsGarage Allegro demo starting");
+
+    if (!al_init()) {
+        log_fatal("al_init() failed — cannot initialise Allegro");
+        return 1;
+    }
+    log_info("Allegro %s initialised",
+             al_id_to_string(al_get_allegro_version()));
+
+    if (!al_install_keyboard()) {
+        log_error("al_install_keyboard() failed");
+        return 1;
+    }
+
+    if (!al_init_primitives_addon()) {
+        log_warn("Primitives addon unavailable — visuals will be minimal");
+    }
+
+    al_init_font_addon();
+
+    ALLEGRO_DISPLAY *display = al_create_display(SCREEN_W, SCREEN_H);
+    if (!display) {
+        log_fatal("Failed to create %dx%d display", SCREEN_W, SCREEN_H);
+        return 1;
+    }
+    al_set_window_title(display, "CarlsGarage — Allegro Demo");
+    log_info("Display created (%dx%d)", SCREEN_W, SCREEN_H);
+
+    ALLEGRO_EVENT_QUEUE *queue = al_create_event_queue();
+    if (!queue) {
+        log_fatal("Failed to create event queue");
+        al_destroy_display(display);
+        return 1;
+    }
+
+    ALLEGRO_TIMER *timer = al_create_timer(1.0 / TARGET_FPS);
+    if (!timer) {
+        log_fatal("Failed to create timer");
+        al_destroy_event_queue(queue);
+        al_destroy_display(display);
+        return 1;
+    }
+
+    al_register_event_source(queue, al_get_keyboard_event_source());
+    al_register_event_source(queue, al_get_display_event_source(display));
+    al_register_event_source(queue, al_get_timer_event_source(timer));
+
+    al_start_timer(timer);
+    log_info("Event loop running — press Escape or close the window to exit");
+
+    int running = 1;
+    int redraw  = 1;
+    float hue   = 0.0f;
+
+    while (running) {
+        ALLEGRO_EVENT ev;
+        al_wait_for_event(queue, &ev);
+
+        switch (ev.type) {
+            case ALLEGRO_EVENT_TIMER:
+                hue = hue + 0.5f;
+                if (hue >= 360.0f) hue -= 360.0f;
+                redraw = 1;
+                break;
+
+            case ALLEGRO_EVENT_KEY_DOWN:
+                if (ev.keyboard.keycode == ALLEGRO_KEY_ESCAPE) {
+                    log_info("Escape pressed — shutting down");
+                    running = 0;
+                }
+                break;
+
+            case ALLEGRO_EVENT_DISPLAY_CLOSE:
+                log_info("Window closed — shutting down");
+                running = 0;
+                break;
+
+            default:
+                break;
+        }
+
+        if (redraw && al_is_event_queue_empty(queue)) {
+            redraw = 0;
+            /* Simple animated background: cycle through hues */
+            float r, g, b;
+            /* Convert HSV (hue, 0.6, 0.9) → RGB the quick way */
+            float h6 = hue / 60.0f;
+            int   i  = (int)h6 % 6;
+            float f  = h6 - (int)h6;
+            float p  = 0.9f * (1.0f - 0.6f);
+            float q  = 0.9f * (1.0f - 0.6f * f);
+            float t2 = 0.9f * (1.0f - 0.6f * (1.0f - f));
+            switch (i) {
+                case 0: r=0.9f; g=t2;   b=p;    break;
+                case 1: r=q;    g=0.9f; b=p;    break;
+                case 2: r=p;    g=0.9f; b=t2;   break;
+                case 3: r=p;    g=q;    b=0.9f; break;
+                case 4: r=t2;   g=p;    b=0.9f; break;
+                default:r=0.9f; g=p;    b=q;    break;
+            }
+            al_clear_to_color(al_map_rgb_f(r, g, b));
+            al_flip_display();
+        }
+    }
+
+    log_info("Cleaning up");
+    al_destroy_timer(timer);
+    al_destroy_event_queue(queue);
+    al_destroy_display(display);
+    log_info("Goodbye from CarlsGarage!");
+    return 0;
+}


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #3

### Plan
Integrate the Allegro 5 game/multimedia library into the CarlsGarage CMake build on Linux, adding a find-package call with a fallback to pkg-config so the library is properly detected and linked. I'll add an optional Allegro-backed demo/example target so the integration is visible and testable, and update the README to document the new dependency and how to install it.

### Summary
Alright folks, welcome back to the garage! Today's job is one I've been meaning to tackle for a while: getting Allegro 5 wired into the CMake build on Linux. Here's what I did. In `CMakeLists.txt` I added a two-stage detection strategy — first we try CMake's own `find_package(Allegro 5)`, and if that comes up empty (which it often will on Linux distros that only ship pkg-config metadata), we fall back to `pkg_check_modules(ALLEGRO allegro-5)` and wrap the result in a proper IMPORTED INTERFACE target so everything downstream can use `target_link_libraries` uniformly. If neither path finds Allegro, the logger library and test suite build exactly as before — no mandatory dependency, no broken builds. When Allegro *is* found, we get a bonus `allegro_demo` executable in `src/allegro_demo/main.c` that opens a window, runs an animated color-cycle loop, and logs every lifecycle event through our own logger — a real integration smoke-test right there in the repo. I also patched the README with install commands for the three big Linux distro families and a note explaining what the CMake output will tell you. Think of it like wiring a new power outlet in the garage: if the breaker's there, great — you get the outlet. If it's not, the rest of the shop still works fine.

### Files Changed
- `CMakeLists.txt` (edit)
- `src/allegro_demo/main.c` (create)
- `README.md` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
