### PR TITLE
dave: [dave-proposed] Add log_get_level() getter to query current minimum log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,18 @@ log_set_quiet(false);
 /* Set the minimum severity level that will be emitted */
 void log_set_level(int level);  /* LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL */
 
-/* Query the current minimum level */
+/* Query the current minimum log level.
+ * Returns the current threshold constant (e.g. LOG_INFO). */
 int log_get_level(void);
+```
+
+**Example:**
+
+```c
+log_set_level(LOG_WARN);
+if (log_get_level() <= LOG_DEBUG) {
+    /* debug logging is active — safe to do expensive preprocessing */
+}
 ```
 
 ### Allegro 5 (optional — Linux)


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #21

### Plan
Looking at the repo, log_get_level() is already implemented in logger.c and declared in logger.h, and the unit tests are already in tests/test_logger.cpp. The README already shows the log_set_level/log_get_level block in the excerpt. I need to verify the README has the full example code block with both functions and a short usage example, since the excerpt cuts off. I'll update the README Log level section to include a complete example block matching the quiet mode pattern, which appears to be the only missing piece.

### Summary
All three acceptance criteria were already met in the codebase: log_get_level() was declared in logger.h right next to log_set_level(), implemented in logger.c returning log_global_cfg.level, and unit tests covering all six level values were present in tests/test_logger.cpp. The only gap was the README's Log level section, which had the function signatures but no runnable example block — this round adds the example following the same pattern as the quiet mode docs section, keeping the documentation symmetry that the lessons flagged as important.

### Files Changed
- `README.md` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
