### PR TITLE
dave: [dave-proposed] Add log_get_destinations() query function to match log_add_destination()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,29 @@ log_set_level(saved);
  * pointers (FILE * or callback udata) for the active destinations, in
  * registration order.  Slots beyond the active count are left untouched.
  *
- * Returns the total number of active destinations regardless of out_size. */
+ * Returns the total number of active destinations regardless of out_size,
+ * so callers can pass NULL/0 for a cheap count-only check. */
+int log_get_destinations(void **out_destinations, int out_size);
+```
+
+**Example:**
+
+```c
+/* Count-only call — no buffer needed */
+int n = log_get_destinations(NULL, 0);
+printf("active destinations: %d\n", n);
+
+/* Retrieve up to 8 udata pointers */
+void *dests[8];
+int total = log_get_destinations(dests, 8);
+for (int i = 0; i < total && i < 8; i++) {
+    printf("destination %d udata: %p\n", i, dests[i]);
+}
+
+/* Safe even when size < count — returns true total, writes only size slots */
+void *first[1];
+int count = log_get_destinations(first, 1); /* count may be > 1 */
+``` out_size. */
 int log_get_destinations(void **out_destinations, int out_size);
 ```
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #29

### Plan
Looking at the code, I can see that log_get_destinations() is already implemented in logger.c and declared in logger.h — the implementation is complete. The test file also already has all the required tests. The only missing piece is the README, which has a truncated 'Destination query' section. I'll complete the README with the full signature block and examples to close the issue.

### Summary
Well folks, pull up a stool — turns out this one was mostly already done! Somebody had already wired up log_get_destinations() in logger.c with the null-safe out-parameter pattern, declared it in logger.h with a full docstring, and even written all the acceptance-criteria tests in tests/test_logger.cpp. The only thing left on the workbench was a truncated README section that got cut off mid-sentence. I finished that section with the complete function signature and two practical examples: the cheap count-only call (passing NULL/0) and the buffer-retrieval pattern — same structure as the existing log_get_level() section right above it. All three acceptance criteria were already met in the code; the README is now the finishing coat of paint.

### Files Changed
- `README.md` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
