### PR TITLE
dave: [dave-proposed] Add unit tests for log_get_level() and log_set_level()

### DIFF
--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -21,6 +21,25 @@ static void reset_logger(void) {
 /* Level API                                                           */
 /* ------------------------------------------------------------------ */
 
+BOOST_AUTO_TEST_CASE(test_get_level_default_is_trace) {
+    reset_logger();
+
+    BOOST_CHECK_EQUAL(log_get_level(), LOG_TRACE);
+}
+
+BOOST_AUTO_TEST_CASE(test_get_level_save_and_restore) {
+    reset_logger();
+
+    log_set_level(LOG_WARN);
+    int saved = log_get_level();
+
+    log_set_level(LOG_ERROR);
+    BOOST_CHECK_EQUAL(log_get_level(), LOG_ERROR);
+
+    log_set_level(saved);
+    BOOST_CHECK_EQUAL(log_get_level(), LOG_WARN);
+}
+
 BOOST_AUTO_TEST_CASE(test_get_level_returns_set_level) {
     reset_logger();
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #31

### Plan
Looking at the issue, I need to check what's already in tests/test_logger.cpp against the three acceptance criteria: (1) default level is LOG_TRACE, (2) get_level returns the value set by set_level for each of the six levels, and (3) save-and-restore pattern works. Criteria (2) is already covered by test_set_level_all_values. Criteria (1) and (3) are missing. I'll add two targeted test cases to cover the default-level check and the save-and-restore pattern.

### Summary
Alright folks, welcome back to the shop! I took a good look under the hood of tests/test_logger.cpp and found that two of the three acceptance criteria from the issue were already sitting on the workbench unfinished. The test for all six levels was already wired up nicely — that one was done. But we were missing a test that confirms the zero-initialized default of LOG_TRACE, and another that exercises the save-and-restore pattern documented right there in the README. I added test_get_level_default_is_trace to verify the out-of-the-box state, and test_get_level_save_and_restore to walk through the exact set/save/change/restore dance the README shows. Both drop in right at the top of the Level API section and use the existing reset_logger() helper just like every other test in the file. Clean, minimal, and the workbench is tidier than we found it.

### Files Changed
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
