### PR TITLE
dave: [dave-proposed] Add test coverage for log_get_level() zero-initialized default

### DIFF
--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -27,6 +27,21 @@ BOOST_AUTO_TEST_CASE(test_get_level_default_is_trace) {
     BOOST_CHECK_EQUAL(log_get_level(), LOG_TRACE);
 }
 
+/* Verify the zero-initialised default: LOG_TRACE == 0, so a never-written
+ * global config struct must already satisfy log_get_level() == LOG_TRACE
+ * without any prior call to log_set_level().  We validate this by zeroing
+ * the struct directly and reading back through the public API. */
+BOOST_AUTO_TEST_CASE(test_get_level_zero_initialized_default) {
+    /* Wipe the entire config struct to simulate a truly fresh, never-touched
+     * state — no log_set_level() call anywhere in the call chain. */
+    memset(&log_global_cfg, 0, sizeof(log_global_cfg));
+
+    BOOST_CHECK_EQUAL(log_get_level(), LOG_TRACE);
+
+    /* Restore to a clean baseline so subsequent tests are not affected. */
+    reset_logger();
+}
+
 BOOST_AUTO_TEST_CASE(test_get_level_save_and_restore) {
     reset_logger();
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #35

### Plan
Looking at the issue and the existing test file, I can see that test_get_level_default_is_trace already exists in tests/test_logger.cpp — it calls reset_logger() and then checks log_get_level() equals LOG_TRACE. However, that test uses reset_logger() which explicitly sets level to LOG_TRACE, so it doesn't truly test the zero-initialized default before any set operation. I need to add a separate test that validates the raw zero-initialized state without relying on reset_logger() to establish it — using the fact that a freshly zeroed struct has level==0==LOG_TRACE.

### Summary
Alright, so here's the thing — the existing test_get_level_default_is_trace case is a good start, but it calls reset_logger() first, which explicitly writes LOG_TRACE into the struct. That means it's really testing 'does get return what reset wrote' rather than 'is the zero-initialized default correct.' The new test_get_level_zero_initialized_default case uses memset to zero the entire config struct — simulating a cold, never-touched global — and then reads back through log_get_level() to confirm it returns LOG_TRACE (which is 0) purely by virtue of C's zero-initialization rules. I restore with reset_logger() at the end so nothing leaks into subsequent cases. Clean, focused, exactly what the issue asked for.

### Files Changed
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
