### PR TITLE
dave: [dave-proposed] Add test for log_get_destinations() with NULL buffer (count-only call)

### DIFF
--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -214,6 +214,26 @@ BOOST_AUTO_TEST_CASE(test_get_destinations_returns_zero_when_empty) {
     BOOST_CHECK_EQUAL(count, 0);
 }
 
+/* Explicitly validate the NULL-buffer count-only call pattern documented in
+ * the README: passing (NULL, 0) returns the active destination count without
+ * requiring the caller to allocate or supply a buffer. */
+BOOST_AUTO_TEST_CASE(test_get_destinations_null_buffer_count_only) {
+    reset_logger();
+
+    /* No destinations yet — count-only call must return 0 safely. */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_INFO);
+
+    /* With two destinations registered, count-only call must return 2. */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 2);
+
+    /* Passing out_size > 0 with a NULL pointer must still return the count
+     * without dereferencing the NULL — callers rely on this being safe. */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 10), 2);
+}
+
 BOOST_AUTO_TEST_CASE(test_get_destinations_counts_registered_destinations) {
     reset_logger();
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #37

### Plan
Looking at the existing tests, I can see there are already several tests for log_get_destinations() with NULL/0 arguments (test_get_destinations_returns_zero_when_empty, test_get_destinations_counts_registered_destinations, test_get_destinations_count_resets_after_remove). However, the issue specifically asks for a dedicated test that explicitly validates the NULL buffer count-only call pattern as a named, self-documenting test case. I'll add a focused test called test_get_destinations_null_buffer_count_only that clearly exercises and documents this contract.

### Summary
Alright, so here's what we've got — the NULL-buffer count-only call pattern for log_get_destinations() was already exercised indirectly by a handful of existing tests, but there was no test that explicitly named, isolated, and documented that specific contract. Think of it like having a load-bearing wall in the garage that everyone walks past without labeling it. I've added test_get_destinations_null_buffer_count_only to tests/test_logger.cpp that directly validates three things: the zero case (no destinations registered), the non-zero case (two destinations registered), and — crucially — that passing a non-zero out_size alongside a NULL pointer is also safe, since callers in the wild might do exactly that. The test sits right alongside the existing destination query tests and follows the same reset_logger/check pattern the rest of the suite uses.

### Files Changed
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
