### PR TITLE
dave: [dave-proposed] Add log_set_destinations() to allow runtime destination management

### DIFF
--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -148,6 +148,12 @@ void log_remove_destinations(void) {
     }
 }
 
+/* clear all registered destinations and reset to a known empty state;
+ * mirrors the pattern of log_set_level() and log_set_quiet() for runtime reconfiguration */
+void log_clear_destinations(void) {
+    log_remove_destinations();
+}
+
 /* populate our log event struct with time and output stream data */
 static void init_event(log_event_t *ev, void *udata) {
     if (!ev->time) {

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -102,6 +102,7 @@ int  log_add_fp(FILE *fp, int level);
 int  log_add_stdout(int level);
 int  log_add_stderr(int level);
 void log_remove_destinations(void);
+void log_clear_destinations(void);
 int  log_get_destinations(void **out_destinations, int out_size);
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -302,6 +302,58 @@ BOOST_AUTO_TEST_CASE(test_get_destinations_respects_out_size_cap) {
 }
 
 /* ------------------------------------------------------------------ */
+/* log_clear_destinations API                                         */
+/* ------------------------------------------------------------------ */
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_removes_all) {
+    reset_logger();
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_INFO);
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+    log_add_fp(fp, LOG_WARN);
+
+    /* Confirm three destinations are registered before clearing */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 3);
+
+    log_clear_destinations();
+
+    /* After clearing, the count must be zero */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    fclose(fp);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_allows_reregistration) {
+    reset_logger();
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_TRACE);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 2);
+
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    /* Slots should be available again from index zero */
+    int rc = log_add_stderr(LOG_WARN);
+    BOOST_CHECK_EQUAL(rc, 0);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_idempotent_on_empty) {
+    reset_logger();
+
+    /* Calling clear on an already-empty list must not crash or corrupt state */
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+}
+
+/* ------------------------------------------------------------------ */
 /* Callback destination                                               */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #39

### Plan
Looking at the existing code, I can see log_remove_destinations() already exists in logger.c and logger.h — the issue asks for log_clear_destinations() as a new public API name. I'll add log_clear_destinations() as an alias/wrapper in both the header and implementation, then add a new test case in tests/test_logger.cpp that verifies calling it removes all destinations and log_get_destinations() returns 0.

### Summary
Alright folks, let's walk through what we did here — it's like adding a reset button to the workbench. The existing codebase already had log_remove_destinations() doing the heavy lifting internally, so log_clear_destinations() is a clean public-facing wrapper that matches the pattern of log_set_level() and log_set_quiet() — all three are runtime configuration reset points. I declared it in logger.h right next to its sibling, implemented it in logger.c as a thin wrapper (so the underlying logic stays in one place, no duplication), and added three new test cases in tests/test_logger.cpp: one that verifies all destinations are gone after a clear, one that confirms re-registration works normally afterward, and one that makes sure calling clear on an already-empty list is safely idempotent. All existing tests remain untouched.

### Files Changed
- `src/logger/logger.h` (edit)
- `src/logger/logger.c` (edit)
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
