### PR TITLE
dave: [dave-proposed] Add log_clear_destinations() to reset registered log outputs

### DIFF
--- a/src/logger/logger_test.c
+++ b/src/logger/logger_test.c
@@ -44,4 +44,53 @@ int main(int argc, char *argv[]) {
             }
         }
     log_info("shr1k");
-}  
+
+    /* ------------------------------------------------------------------ *
+     * Tests for log_clear_destinations()                                  *
+     * ------------------------------------------------------------------ */
+
+    /* Test 1: clear an empty destination list — idempotency guard.
+     * Calling clear when nothing is registered should be a no-op and
+     * not blow anything up (no double-free, no counter underflow). */
+    log_clear_destinations();
+    int count_after_empty_clear = log_get_destinations(NULL, 0);
+    if (count_after_empty_clear != 0) {
+        log_error("FAIL: clear on empty list — expected 0 destinations, got %d",
+                  count_after_empty_clear);
+        return EXIT_FAILURE;
+    }
+    log_info("PASS: log_clear_destinations() on empty list is idempotent");
+
+    /* Test 2: populate the list, clear it, verify count drops to zero. */
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_TRACE);
+    int count_before_clear = log_get_destinations(NULL, 0);
+    if (count_before_clear != 2) {
+        log_error("FAIL: pre-clear setup — expected 2 destinations, got %d",
+                  count_before_clear);
+        return EXIT_FAILURE;
+    }
+    log_clear_destinations();
+    int count_after_clear = log_get_destinations(NULL, 0);
+    if (count_after_clear != 0) {
+        log_error("FAIL: after clear — expected 0 destinations, got %d",
+                  count_after_clear);
+        return EXIT_FAILURE;
+    }
+    log_info("PASS: log_clear_destinations() drops populated list to zero");
+
+    /* Test 3: clear, then re-register new destinations to confirm the list
+     * is truly reset and accepts fresh registrations without issues. */
+    log_clear_destinations();
+    log_add_stderr(LOG_WARN);
+    int count_after_rereg = log_get_destinations(NULL, 0);
+    if (count_after_rereg != 1) {
+        log_error("FAIL: re-register after clear — expected 1 destination, got %d",
+                  count_after_rereg);
+        return EXIT_FAILURE;
+    }
+    log_info("PASS: re-registration after log_clear_destinations() works correctly");
+
+    /* leave the destination list clean for any downstream code */
+    log_clear_destinations();
+}


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #41

### Plan
Looking at the repo, I can see that log_clear_destinations() is already declared in logger.h and implemented in logger.c as a thin wrapper around log_remove_destinations(). The only thing missing is the three test cases in logger_test.c: (1) clear an empty list, (2) clear a populated list and verify count drops to zero, (3) clear and re-register. I'll add those three test cases to logger_test.c.

### Summary
Well hey folks, welcome back to the garage! Turns out most of the heavy lifting was already done — log_clear_destinations() was already declared in logger.h and wired up in logger.c as a clean thin wrapper around log_remove_destinations(), just like the issue asked for. All that was left on the workbench was the test harness. I added three test cases to logger_test.c: the idempotency guard that calls clear on an already-empty list (the kind of edge case that bites you at 2am when you're on call), a populate-then-clear test that verifies the count drops to zero, and a clear-then-re-register test that confirms the list is genuinely reset and ready to accept new destinations. Back in my Windows NT days we called that 'trust but verify' — you don't just assume the reset worked, you prove it. All three acceptance criteria from the issue are now met.

### Files Changed
- `src/logger/logger_test.c` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
