### PR TITLE
dave: [dave-proposed] Add log_set_destinations() to bulk-configure log outputs

### DIFF
--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -1,4 +1,5 @@
 #include "logger.h"
+#include <string.h>
 
 #define MAX_LOG_DESTINATIONS 420
 
@@ -152,6 +153,36 @@ void log_remove_destinations(void) {
  * mirrors the pattern of log_set_level() and log_set_quiet() for runtime reconfiguration */
 void log_clear_destinations(void) {
     log_remove_destinations();
+}
+
+/**
+ * Atomically replace the entire destination list with the provided array of udata pointers.
+ *
+ * Each pointer in destinations[] is registered via log_add_fp() using LOG_TRACE as the
+ * minimum level.  If any registration fails (e.g., the table is full), the original
+ * destination list is restored and -1 is returned so the caller is never left in a
+ * partial state.
+ *
+ * @param destinations  Array of FILE * (cast to void *) to register as new destinations.
+ * @param count         Number of entries in the destinations array.
+ * @return              0 on success, -1 if any registration failed (old list preserved).
+ */
+int log_set_destinations(void **destinations, int count) {
+    /* Snapshot the current destination table so we can roll back on failure. */
+    log_dest_t saved[MAX_LOG_DESTINATIONS];
+    memcpy(saved, log_global_cfg.destinations, sizeof(saved));
+
+    log_clear_destinations();
+
+    for (int i = 0; i < count; i++) {
+        if (log_add_fp((FILE *)destinations[i], LOG_TRACE) != 0) {
+            /* Registration failed — restore the previous destination list. */
+            memcpy(log_global_cfg.destinations, saved, sizeof(saved));
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 /* populate our log event struct with time and output stream data */

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -104,5 +104,6 @@ int  log_add_stderr(int level);
 void log_remove_destinations(void);
 void log_clear_destinations(void);
 int  log_get_destinations(void **out_destinations, int out_size);
+int  log_set_destinations(void **destinations, int count);
 
 void log_log(int level, const char *file, int line, const char *fmt, ...);

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -4,6 +4,7 @@ extern "C" {
 
 #include <cstdio>
 #include <cstring>
+#include <cstdlib>
 
 #define BOOST_TEST_MODULE LoggerTest
 #include <boost/test/included/unit_test.hpp>
@@ -351,6 +352,138 @@ BOOST_AUTO_TEST_CASE(test_clear_destinations_idempotent_on_empty) {
 
     log_clear_destinations();
     BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* log_set_destinations API                                           */
+/* ------------------------------------------------------------------ */
+
+BOOST_AUTO_TEST_CASE(test_set_destinations_bulk_success) {
+    reset_logger();
+
+    FILE *fp1 = tmpfile();
+    FILE *fp2 = tmpfile();
+    BOOST_REQUIRE(fp1 != NULL);
+    BOOST_REQUIRE(fp2 != NULL);
+
+    void *dests[2] = { (void *)fp1, (void *)fp2 };
+    int rc = log_set_destinations(dests, 2);
+
+    BOOST_CHECK_EQUAL(rc, 0);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 2);
+
+    /* Verify the query round-trip returns the same pointers in order */
+    void *out[2] = {NULL, NULL};
+    log_get_destinations(out, 2);
+    BOOST_CHECK_EQUAL(out[0], (void *)fp1);
+    BOOST_CHECK_EQUAL(out[1], (void *)fp2);
+
+    fclose(fp1);
+    fclose(fp2);
+}
+
+BOOST_AUTO_TEST_CASE(test_set_destinations_replaces_existing_list) {
+    reset_logger();
+
+    /* Seed an initial destination */
+    log_add_stderr(LOG_TRACE);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 1);
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+
+    void *dests[1] = { (void *)fp };
+    int rc = log_set_destinations(dests, 1);
+
+    BOOST_CHECK_EQUAL(rc, 0);
+    /* Old stderr destination should be gone; only fp remains */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 1);
+
+    void *out[2] = {NULL, NULL};
+    log_get_destinations(out, 2);
+    BOOST_CHECK_EQUAL(out[0], (void *)fp);
+    BOOST_CHECK_EQUAL(out[1], (void *)NULL);
+
+    fclose(fp);
+}
+
+BOOST_AUTO_TEST_CASE(test_set_destinations_set_then_query_roundtrip) {
+    reset_logger();
+
+    FILE *fp1 = tmpfile();
+    FILE *fp2 = tmpfile();
+    FILE *fp3 = tmpfile();
+    BOOST_REQUIRE(fp1 != NULL);
+    BOOST_REQUIRE(fp2 != NULL);
+    BOOST_REQUIRE(fp3 != NULL);
+
+    void *dests[3] = { (void *)fp1, (void *)fp2, (void *)fp3 };
+    BOOST_REQUIRE_EQUAL(log_set_destinations(dests, 3), 0);
+
+    void *out[3] = {NULL, NULL, NULL};
+    int count = log_get_destinations(out, 3);
+
+    BOOST_CHECK_EQUAL(count, 3);
+    BOOST_CHECK_EQUAL(out[0], (void *)fp1);
+    BOOST_CHECK_EQUAL(out[1], (void *)fp2);
+    BOOST_CHECK_EQUAL(out[2], (void *)fp3);
+
+    fclose(fp1);
+    fclose(fp2);
+    fclose(fp3);
+}
+
+BOOST_AUTO_TEST_CASE(test_set_destinations_empty_list_clears_all) {
+    reset_logger();
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_TRACE);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 2);
+
+    /* Setting an empty destination list should wipe everything cleanly */
+    int rc = log_set_destinations(NULL, 0);
+    BOOST_CHECK_EQUAL(rc, 0);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_set_destinations_partial_failure_preserves_old_list) {
+    reset_logger();
+
+    /* Register a known good destination to form the "old" list */
+    log_add_stderr(LOG_TRACE);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 1);
+
+    /* Fill the destination table to its brim so the second add inside
+     * log_set_destinations() will fail, triggering the rollback path. */
+    for (int i = 1; i < MAX_LOG_DESTINATIONS; i++) {
+        log_add_stderr(LOG_TRACE);
+    }
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), MAX_LOG_DESTINATIONS);
+
+    /* Now attempt to set two destinations — the table is full after clearing
+     * and re-adding the first one, so the second add must fail and roll back. */
+    FILE *fp1 = tmpfile();
+    FILE *fp2 = tmpfile();
+    BOOST_REQUIRE(fp1 != NULL);
+    BOOST_REQUIRE(fp2 != NULL);
+
+    /* We need exactly MAX_LOG_DESTINATIONS + 1 new entries to force failure.
+     * Simpler approach: request more destinations than the table can hold. */
+    void **big_dests = (void **)malloc((MAX_LOG_DESTINATIONS + 1) * sizeof(void *));
+    BOOST_REQUIRE(big_dests != NULL);
+    for (int i = 0; i <= MAX_LOG_DESTINATIONS; i++) {
+        big_dests[i] = (void *)fp1;
+    }
+
+    int rc = log_set_destinations(big_dests, MAX_LOG_DESTINATIONS + 1);
+
+    /* Must fail and the old list of MAX_LOG_DESTINATIONS entries must be intact */
+    BOOST_CHECK_EQUAL(rc, -1);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), MAX_LOG_DESTINATIONS);
+
+    free(big_dests);
+    fclose(fp1);
+    fclose(fp2);
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #43

### Plan
Add log_set_destinations() declaration to logger.h, implement it in logger.c as a transactional wrapper that saves the old state, clears, attempts each add, and rolls back on failure, then write test cases in tests/test_logger.cpp covering bulk-set success, partial-failure recovery, and set-then-query round-trip.

### Summary
Alright folks, let's wire this thing up! I've added `log_set_destinations()` to the header, implemented it in logger.c as a transactional wrapper — it snapshots the current destination table, clears it, tries each new registration, and rolls back to the snapshot if anything goes sideways (same kind of defensive pattern I used to write for NT kernel paths back in the day — you never want to leave the system in a half-baked state). I also needed to pull in `<string.h>` for `memcpy` since the implementation uses it for the snapshot/restore. On the test side I added five new test cases to tests/test_logger.cpp: bulk-set success, replace-existing-list, set-then-query round-trip, empty-list-clears-all, and the partial-failure recovery path that verifies the old list is preserved intact when the table overflows.

### Files Changed
- `src/logger/logger.h` (edit)
- `src/logger/logger.c` (edit)
- `src/logger/logger.c` (edit)
- `tests/test_logger.cpp` (edit)
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
