### PR TITLE
dave: [dave-proposed] Add log_clear_destinations() to reset the destination registry

### DIFF
--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -446,6 +446,58 @@ BOOST_AUTO_TEST_CASE(test_set_destinations_empty_list_clears_all) {
     BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
 }
 
+BOOST_AUTO_TEST_CASE(test_clear_destinations_removes_all) {
+    reset_logger();
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_INFO);
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+    log_add_fp(fp, LOG_WARN);
+
+    /* Confirm three destinations are registered before clearing */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 3);
+
+    log_clear_destinations();
+
+    /* After clearing, the count must be zero */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    fclose(fp);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_allows_reregistration) {
+    reset_logger();
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_TRACE);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 2);
+
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    /* Slots should be available again from index zero */
+    int rc = log_add_stderr(LOG_WARN);
+    BOOST_CHECK_EQUAL(rc, 0);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_idempotent_on_empty) {
+    reset_logger();
+
+    /* Calling clear on an already-empty list must not crash or corrupt state */
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* log_set_destinations API                                           */
+/* ------------------------------------------------------------------ */
+
 BOOST_AUTO_TEST_CASE(test_set_destinations_partial_failure_preserves_old_list) {
     reset_logger();
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #45

### Plan
Looking at the repo, log_clear_destinations() is already declared in logger.h and implemented in logger.c (delegating to log_remove_destinations()). The C test file logger_test.c also already has tests. What's missing are the Boost unit tests in tests/test_logger.cpp — I can see the file is truncated but the test cases for log_clear_destinations() need to be added there to satisfy acceptance criteria.

### Summary
Well folks, it looks like most of the heavy lifting was already done — log_clear_destinations() was declared in logger.h, implemented in logger.c (as a clean wrapper around log_remove_destinations()), and even had test coverage in the C test file. The only thing missing was the Boost unit test coverage in tests/test_logger.cpp, which had the file truncated right before the set_destinations tests. I've added the three Boost test cases that cover the acceptance criteria: clear-removes-all, clear-then-re-register, and the idempotent double-clear on an empty list. That rounds out the full test suite and closes out the issue neatly — like finding the last socket you need is already in the toolbox, you just had to look in the right drawer.

### Files Changed
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
