### PR TITLE
dave: [dave-proposed] Add log_level_name() helper to convert log_level_t to string

### DIFF
--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -64,6 +64,13 @@ static void log_to_stream(log_event_t *ev) {
 
 }
 
+const char* log_level_name(int level) {
+    if (level < LOG_TRACE || level > LOG_FATAL) {
+        return "UNKNOWN";
+    }
+    return level_strings[level];
+}
+
 //so we're here, and we want to set log level to 0
 int log_get_level(void) {
     return log_global_cfg.level;

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -93,6 +93,19 @@ enum {
 
 /* function declarations, all of our function definitions live in the logger.c file */
 const char* log_level_string(int level);
+
+/**
+ * Convert a log_level_t value to its human-readable name.
+ *
+ * Returns the uppercase string name for each valid severity level:
+ * LOG_TRACE -> "TRACE", LOG_DEBUG -> "DEBUG", LOG_INFO -> "INFO",
+ * LOG_WARN  -> "WARN",  LOG_ERROR -> "ERROR", LOG_FATAL -> "FATAL".
+ * Any value outside the valid range [LOG_TRACE, LOG_FATAL] returns "UNKNOWN".
+ *
+ * @param level  A log_level_t (or int) severity value.
+ * @return       A pointer to a string literal; never NULL.
+ */
+const char* log_level_name(int level);
 int  log_set_level(int level);
 int  log_get_level(void);
 void log_set_quiet(bool enable);

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -19,6 +19,48 @@ static void reset_logger(void) {
 }
 
 /* ------------------------------------------------------------------ */
+/* log_level_name API                                                  */
+/* ------------------------------------------------------------------ */
+
+BOOST_AUTO_TEST_CASE(test_level_name_trace) {
+    BOOST_CHECK_EQUAL(std::string(log_level_name(LOG_TRACE)), "TRACE");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_name_debug) {
+    BOOST_CHECK_EQUAL(std::string(log_level_name(LOG_DEBUG)), "DEBUG");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_name_info) {
+    BOOST_CHECK_EQUAL(std::string(log_level_name(LOG_INFO)), "INFO");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_name_warn) {
+    BOOST_CHECK_EQUAL(std::string(log_level_name(LOG_WARN)), "WARN");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_name_error) {
+    BOOST_CHECK_EQUAL(std::string(log_level_name(LOG_ERROR)), "ERROR");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_name_fatal) {
+    BOOST_CHECK_EQUAL(std::string(log_level_name(LOG_FATAL)), "FATAL");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_name_out_of_range_returns_unknown) {
+    BOOST_CHECK_EQUAL(std::string(log_level_name(-1)),  "UNKNOWN");
+    BOOST_CHECK_EQUAL(std::string(log_level_name(999)), "UNKNOWN");
+    BOOST_CHECK_EQUAL(std::string(log_level_name(LOG_FATAL + 1)), "UNKNOWN");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_name_never_returns_null) {
+    /* Every valid level and one invalid level must return a non-NULL pointer. */
+    const int probes[] = { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL, -1, 42 };
+    for (int i = 0; i < 8; i++) {
+        BOOST_CHECK(log_level_name(probes[i]) != NULL);
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /* Level API                                                           */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #52

### Plan
The header already declares `log_level_string()` and the implementation uses `level_strings[]` internally, but the issue asks for `log_level_name()` with 'UNKNOWN' fallback for out-of-range values. I'll add the `log_level_name()` declaration to logger.h, implement it in logger.c, and add unit tests covering all six valid levels plus one out-of-range value in test_logger.cpp.

### Summary
Alright folks, let me walk you through what we did here — it's a clean little three-part job, like adding a new labeled drawer to the toolbox. First, we declared `log_level_name()` in logger.h with a proper docstring so callers know exactly what to expect, including the 'UNKNOWN' fallback behavior for bad inputs. Then we dropped a tight implementation into logger.c that piggybacks on the existing `level_strings[]` lookup table — bounds-check first, array index second, just like you'd check a socket size before jamming the wrench on. Finally we wired up seven test cases in test_logger.cpp: one for each of the six valid severity levels (TRACE through FATAL), one that fires three different out-of-range probes and expects 'UNKNOWN' back each time, and a null-safety sweep confirming the function never hands back a NULL pointer under any input. All three acceptance criteria from the issue are satisfied — declaration, implementation, and full test coverage.

### Files Changed
- `src/logger/logger.h` (edit)
- `src/logger/logger.c` (edit)
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
