### PR TITLE
dave: [dave-proposed] Add log_clear_destinations() to reset all registered destinations

### DIFF
--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -445,6 +445,58 @@ BOOST_AUTO_TEST_CASE(test_clear_destinations_idempotent_on_empty) {
 }
 
 /* ------------------------------------------------------------------ */
+/* log_clear_destinations API                                         */
+/* ------------------------------------------------------------------ */
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_removes_all) {
+    reset_logger();
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_INFO);
+
+    FILE *fp = tmpfile();
+    BOOST_REQUIRE(fp != NULL);
+    log_add_fp(fp, LOG_WARN);
+
+    /* Confirm three destinations are registered before clearing */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 3);
+
+    log_clear_destinations();
+
+    /* After clearing, the count must be zero */
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    fclose(fp);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_allows_reregistration) {
+    reset_logger();
+
+    log_add_stderr(LOG_TRACE);
+    log_add_stdout(LOG_TRACE);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 2);
+
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    /* Slots should be available again from index zero */
+    int rc = log_add_stderr(LOG_WARN);
+    BOOST_CHECK_EQUAL(rc, 0);
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_clear_destinations_idempotent_on_empty) {
+    reset_logger();
+
+    /* Calling clear on an already-empty list must not crash or corrupt state */
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+
+    log_clear_destinations();
+    BOOST_CHECK_EQUAL(log_get_destinations(NULL, 0), 0);
+}
+
+/* ------------------------------------------------------------------ */
 /* log_set_destinations API                                           */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #54

### Plan
Looking at the repository, I can see that log_clear_destinations() is already declared in logger.h and implemented in logger.c (it delegates to log_remove_destinations()). The only thing missing is the three test cases in tests/test_logger.cpp. I'll add the three required test cases — populate-then-clear, clear-then-re-register, and double-clear on empty — in the existing log_clear_destinations API section of the test file.

### Summary
Well, good news from the garage — turns out the hard work was already done! Cracking open the source files, I found that log_clear_destinations() is already declared right next to log_get_destinations() in logger.h and implemented in logger.c (it delegates cleanly to log_remove_destinations(), which does the zero-out sweep). The only thing left on the workbench was the three test cases the issue specifies. I dropped them into tests/test_logger.cpp in the existing log_clear_destinations API section: (1) populate-then-clear confirms the count drops to zero, (2) clear-then-re-register confirms the slot scanner isn't stuck and slots are truly reusable, and (3) double-clear on an empty list guards against any counter underflow or crash when the function is called in an unexpected order. All three follow the same reset_logger() / BOOST_CHECK_EQUAL pattern already established in the file.

### Files Changed
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
