### PR TITLE
dave: [dave-proposed] Add log_level_to_string() helper for runtime level inspection

### DIFF
--- a/src/logger/logger.c
+++ b/src/logger/logger.c
@@ -64,6 +64,13 @@ static void log_to_stream(log_event_t *ev) {
 
 }
 
+const char* log_level_string(int level) {
+    if (level < LOG_TRACE || level > LOG_FATAL) {
+        return "UNKNOWN";
+    }
+    return level_strings[level];
+}
+
 const char* log_level_name(int level) {
     if (level < LOG_TRACE || level > LOG_FATAL) {
         return "UNKNOWN";

--- a/tests/test_logger.cpp
+++ b/tests/test_logger.cpp
@@ -61,6 +61,60 @@ BOOST_AUTO_TEST_CASE(test_level_name_never_returns_null) {
 }
 
 /* ------------------------------------------------------------------ */
+/* log_level_to_string / log_level_string API                          */
+/* ------------------------------------------------------------------ */
+
+BOOST_AUTO_TEST_CASE(test_level_string_trace) {
+    BOOST_CHECK_EQUAL(std::string(log_level_string(LOG_TRACE)), "TRACE");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_debug) {
+    BOOST_CHECK_EQUAL(std::string(log_level_string(LOG_DEBUG)), "DEBUG");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_info) {
+    BOOST_CHECK_EQUAL(std::string(log_level_string(LOG_INFO)), "INFO");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_warn) {
+    BOOST_CHECK_EQUAL(std::string(log_level_string(LOG_WARN)), "WARN");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_error) {
+    BOOST_CHECK_EQUAL(std::string(log_level_string(LOG_ERROR)), "ERROR");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_fatal) {
+    BOOST_CHECK_EQUAL(std::string(log_level_string(LOG_FATAL)), "FATAL");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_out_of_range_returns_unknown) {
+    BOOST_CHECK_EQUAL(std::string(log_level_string(-1)),  "UNKNOWN");
+    BOOST_CHECK_EQUAL(std::string(log_level_string(999)), "UNKNOWN");
+    BOOST_CHECK_EQUAL(std::string(log_level_string(LOG_FATAL + 1)), "UNKNOWN");
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_never_returns_null) {
+    const int probes[] = { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL, -1, 42 };
+    for (int i = 0; i < 8; i++) {
+        BOOST_CHECK(log_level_string(probes[i]) != NULL);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_level_string_combined_with_get_level) {
+    reset_logger();
+
+    /* The canonical use-case from the issue: query the level, convert to string. */
+    log_set_level(LOG_WARN);
+    int current = log_get_level();
+    BOOST_CHECK_EQUAL(std::string(log_level_string(current)), "WARN");
+
+    log_set_level(LOG_ERROR);
+    current = log_get_level();
+    BOOST_CHECK_EQUAL(std::string(log_level_string(current)), "ERROR");
+}
+
+/* ------------------------------------------------------------------ */
 /* Level API                                                           */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## 🔧 Dave's Garage — Implementation

Closes #56

### Plan
Looking at the existing code, I can see that `log_level_name()` is already declared in `logger.h` and implemented in `logger.c`, and the tests for it already exist in `tests/test_logger.cpp`. The issue asks to expose `log_level_to_string()` but the repo already implemented it as `log_level_name()`. I need to check if there's also a `log_level_string()` declared in the header that needs a body, and whether the issue is truly already resolved. The header declares both `log_level_string()` and `log_level_name()` — I need to add the implementation for `log_level_string()` (or alias it) since only `log_level_name()` has a body in logger.c.

### Summary
Well, pull up a stool — turns out this garage already had most of the parts on the shelf. The `log_level_name()` function was already declared and implemented, and its tests were already wired up. What *was* missing was the body for `log_level_string()`, which the header declared but logger.c never defined — like a circuit breaker labeled but not wired to anything. I added the `log_level_string()` implementation in logger.c (same bounds-check-plus-index pattern as `log_level_name()`), and added a full suite of Boost test cases covering every valid level, out-of-range sentinel behavior, the never-NULL contract, and the canonical combined use-case of `log_get_level()` + `log_level_string()` that the issue specifically called out as the motivating scenario.

### Files Changed
- `src/logger/logger.c` (edit)
- `tests/test_logger.cpp` (edit)

---
*Automated by [Dave](https://github.com/JackFurton/daves-garage) — autonomous coding loop with personality.*
